### PR TITLE
Fix HikariDataSource Config Issue

### DIFF
--- a/stage-2/src/middleware-projects/distributed-transaction-project/src/main/java/com/acme/middleware/distributed/transaction/config/DataSourceConfiguration.java
+++ b/stage-2/src/middleware-projects/distributed-transaction-project/src/main/java/com/acme/middleware/distributed/transaction/config/DataSourceConfiguration.java
@@ -21,16 +21,13 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
 import org.springframework.jdbc.datasource.lookup.BeanFactoryDataSourceLookup;
 import org.springframework.jdbc.datasource.lookup.DataSourceLookup;
-import org.springframework.util.StringUtils;
 
 import javax.sql.DataSource;
 import java.util.Map;
@@ -42,7 +39,6 @@ import java.util.Map;
  * @since 1.0.0
  */
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties
 public class DataSourceConfiguration {
 
     @Autowired
@@ -53,8 +49,8 @@ public class DataSourceConfiguration {
      */
     @Bean
     @ConfigurationProperties(prefix = "datasources.write")
-    public DataSource writeDataSource(DataSourceProperties properties) {
-        return dataSource(properties);
+    public DataSource writeDataSource() {
+       return new HikariDataSource();
     }
 
     /**
@@ -62,8 +58,8 @@ public class DataSourceConfiguration {
      */
     @Bean
     @ConfigurationProperties(prefix = "datasources.read")
-    public DataSource readDataSource(DataSourceProperties properties) {
-        return dataSource(properties);
+    public DataSource readDataSource() {
+        return new HikariDataSource();
     }
 
     @Bean
@@ -81,17 +77,5 @@ public class DataSourceConfiguration {
     @Bean
     public BeanFactoryDataSourceLookup dataSourceLookup() {
         return new BeanFactoryDataSourceLookup();
-    }
-
-    HikariDataSource dataSource(DataSourceProperties properties) {
-        HikariDataSource dataSource = createDataSource(properties, HikariDataSource.class);
-        if (StringUtils.hasText(properties.getName())) {
-            dataSource.setPoolName(properties.getName());
-        }
-        return dataSource;
-    }
-
-    protected static <T> T createDataSource(DataSourceProperties properties, Class<? extends DataSource> type) {
-        return (T) properties.initializeDataSourceBuilder().type(type).build();
     }
 }

--- a/stage-2/src/middleware-projects/distributed-transaction-project/src/main/resources/application-datasources.yaml
+++ b/stage-2/src/middleware-projects/distributed-transaction-project/src/main/resources/application-datasources.yaml
@@ -4,10 +4,10 @@ spring:
 
 datasources:
   write:
-    url: jdbc:mysql://127.0.0.1:13306/tx_db
+    jdbc-url: jdbc:mysql://127.0.0.1:13306/test_db
     user-name: root
     password: 123456
   read:
-    url: jdbc:mysql://127.0.0.1:13307/tx_db
+    jdbc-url: jdbc:mysql://127.0.0.1:13307/test_db
     user-name: root
     password: 123456


### PR DESCRIPTION
改动后的代码：
```java
    @Bean
    @ConfigurationProperties(prefix = "datasources.write")
    public DataSource writeDataSource() {
       return new HikariDataSource();
    }
```
此处 HikariDataSource 的属性注入是在 `org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor#postProcessBeforeInitialization
` 执行 。


之前的代码：

```java
    @Bean
    @ConfigurationProperties(prefix = "datasources.write")
    public DataSource writeDataSource(DataSourceProperties properties) {
        return dataSource(properties);
    }
```

之前方法参数中注入的 DataSourceProperties 实际上就是以 spring.datasource 开头的配置，工程中没有配置，所以都为空。
报错也是因为 DataSourceProperties 为空，找不到 driverClassName ，详见 `org.springframework.boot.autoconfigure.jdbc.DataSourceProperties#determineDriverClassName`